### PR TITLE
Don't include objects in parameter values

### DIFF
--- a/datamodel/datamodel.go
+++ b/datamodel/datamodel.go
@@ -53,7 +53,11 @@ func (dm *DataModel) GetAll(path string) []Parameter {
 	if strings.HasSuffix(path, ".") {
 		for k, p := range dm.Values {
 			if strings.HasPrefix(k, path) {
+				if p.Type == "" {
+					continue
+				}
 				params = append(params, p)
+
 			}
 		}
 	} else if p, ok := dm.Values[path]; ok {

--- a/server/get_parameter_names.go
+++ b/server/get_parameter_names.go
@@ -12,6 +12,9 @@ func (s *Server) handleGetParameterNames(envID string, r *rpc.GetParameterNamesR
 	names := s.dm.ParameterNames(r.ParameterPath, r.NextLevel)
 	params := make([]rpc.ParameterInfoStruct, 0, len(names))
 	for _, p := range names {
+		if p.Type == "" {
+			continue
+		}
 		params = append(params, rpc.ParameterInfoStruct{
 			Name:     p.Path,
 			Writable: p.Writable,


### PR DESCRIPTION
Probably not an actual solution, but a conceptual one.

This stops the simulator from sending Objects as parameter values, and only sends the object contents, based on the assumption that an object doesn't have a type.

This fixes deal breaking connectivity problems with MountainView ACS 