### PR TITLE
Read out assigned port from http server

### DIFF
--- a/server/inform.go
+++ b/server/inform.go
@@ -71,6 +71,7 @@ func (s *Server) Inform(ctx context.Context) {
 	s.metrics.ConcurrentInforms.Inc()
 	s.metrics.ConnectionLatency.Observe(float64(time.Since(connectionStartTime).Milliseconds()))
 
+	log.Info().Str("acs_url", Config.ACSURL).Msg("Connecting to ACS")
 	client, closeFn, err := newClient(u.Hostname(), tcpPort(u))
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to connect to ACS")

--- a/server/server.go
+++ b/server/server.go
@@ -35,8 +35,6 @@ type Server struct {
 
 // Start starts the server.
 func (s *Server) Start(ctx context.Context) error {
-	log.Info().Str("server_url", s.URL()).Msg("Starting server")
-
 	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", Config.Host, Config.Port))
 	if err != nil {
 		return fmt.Errorf("create TCP listener: %w", err)
@@ -47,6 +45,7 @@ func (s *Server) Start(ctx context.Context) error {
 	s.SetPeriodicInformInterval(Config.InformInterval)
 	go s.periodicInform(ctx)
 
+	log.Info().Str("server_url", s.URL()).Msg("Starting server")
 	return s.httpServer.Serve(listener)
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -25,7 +25,7 @@ import (
 type Server struct {
 	httpServer           *http.Server
 	listener             net.Listener
-	addr                 String
+	addr                 string
 	dm                   *datamodel.DataModel
 	cookies              http.CookieJar
 	informScheduleUpdate chan struct{}


### PR DESCRIPTION
By explicitly declaring the listener, we can extract the OS assigned port from it.