### PR TITLE
Make envelope ID specific to a server

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,14 +11,17 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    - copyloopvar
+    - decorder
     - dupl
     - dupword
     - durationcheck
     - errchkjson
-    - errorlint
     - errname
-    - copyloopvar
+    - errorlint
+    - gochecknoglobals
     - goconst
+    - goimports
     - gocritic
     - gocyclo
     - gosec

--- a/cmd/convert/main.go
+++ b/cmd/convert/main.go
@@ -1,5 +1,6 @@
 // This package allows to convert datamodels into a CSV format that is supported
 // by this simulator.
+// nolint:gochecknoglobals
 package main
 
 import (

--- a/server/config.go
+++ b/server/config.go
@@ -13,6 +13,7 @@ import (
 )
 
 // Config is a global configuration store.
+// nolint:gochecknoglobals
 var Config struct {
 	// LogLevel controls how verbose the levels are. Supported values: trace,
 	// debug, info, warn, error, fatal, panic.

--- a/server/inform.go
+++ b/server/inform.go
@@ -176,7 +176,7 @@ func (s *Server) makeInformEnvelope() *rpc.EnvelopeEncoder {
 	}
 	s.dm.ClearNotifyParams()
 
-	env := newEnvelope()
+	env := s.newEnvelope()
 	env.Body.Inform = &rpc.InformRequestEncoder{
 		DeviceId: rpc.DeviceID{
 			Manufacturer: deviceID.Manufacturer,

--- a/server/server.go
+++ b/server/server.go
@@ -30,6 +30,7 @@ type Server struct {
 	informScheduleUpdate chan struct{}
 	stop                 chan struct{}
 	startedAt            time.Time
+	envelopeID           uint64
 	informMux            sync.Mutex
 	metrics              *metrics.Metrics
 }
@@ -208,14 +209,12 @@ func (s *Server) stopped() bool {
 	}
 }
 
-var envelopeID uint64
-
-func newEnvelope() *rpc.EnvelopeEncoder {
-	return rpc.NewEnvelope(nextEnvelopeID())
+func (s *Server) newEnvelope() *rpc.EnvelopeEncoder {
+	return rpc.NewEnvelope(s.nextEnvelopeID())
 }
 
-func nextEnvelopeID() string {
-	id := atomic.AddUint64(&envelopeID, 1)
+func (s *Server) nextEnvelopeID() string {
+	id := atomic.AddUint64(&s.envelopeID, 1)
 	return strconv.FormatUint(id, 10)
 }
 


### PR DESCRIPTION
Envelope ID serial used to be global. When running multiple simulators within the same process it only make sense to have a dedicated serial for each server.