### PR TITLE
Error out consistently

### DIFF
--- a/server/get_parameter_values.go
+++ b/server/get_parameter_values.go
@@ -14,6 +14,7 @@ func (s *Server) handleGetParameterValues(envID string, r *rpc.GetParameterValue
 	for _, path := range names {
 		batch := s.dm.GetAll(path)
 		if batch == nil {
+			params = []rpc.ParameterValueEncoder{}
 			break
 		}
 		for _, p := range batch {


### PR DESCRIPTION
If a long list of batch parameters are queried, it's important to return 9005 no matter where in the list the missing parameter is.

This change explicitly empties the parameter list that's been gathered so far when a non-existing parameter is encountered.