### PR TITLE
Perform first inform asynchronously 

### DIFF
--- a/server/inform.go
+++ b/server/inform.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (s *Server) periodicInform(ctx context.Context) {
-	s.inform(ctx)
+	go s.inform(ctx)
 	for !s.stopped() {
 		if !s.dm.PeriodicInformEnabled() {
 			log.Info().Msg("Periodic inform disabled")


### PR DESCRIPTION
If an ACS attempts to change inform schedule during the first session (bootstrap/boot) simulator will deadlock because inform scheduling loop has not started yet. Starting the first inform asynchronously unblocks the inform scheduling routine and should avoid such deadlocks.